### PR TITLE
Remove unused dependency ($translate) from the registration controller

### DIFF
--- a/src/main/webapp/app/authentication/controllers/register.controller.js
+++ b/src/main/webapp/app/authentication/controllers/register.controller.js
@@ -1,10 +1,9 @@
 angular.module('authentication')
-    .controller('RegisterController', function ($scope, $translate, AccountService, Auth, $state) {
+    .controller('RegisterController', function ($scope, AccountService, Auth, $state) {
         $scope.error = null;
         $scope.account = {};
 
         $scope.register = function () {
-            $scope.account.langKey = $translate.use();
             $scope.error = null;
             $scope.errorEmailExists = null;
 

--- a/src/test/javascript/spec/authentication/register.controller.spec.js
+++ b/src/test/javascript/spec/authentication/register.controller.spec.js
@@ -11,7 +11,6 @@ describe('Controller Tests', function () {
             $q = _$q_;
             $scope = $rootScope.$new();
             MockAccountService = jasmine.createSpyObj('MockAccountService', ['register']);
-            MockTranslate = jasmine.createSpyObj('MockTranslate', ['use']);
             MockAuth = jasmine.createSpyObj('Auth', ['login']);
             MockState = jasmine.createSpyObj('$state', ['go']);
 
@@ -19,7 +18,6 @@ describe('Controller Tests', function () {
                 '$scope': $scope,
                 'AccountService': MockAccountService,
                 'Auth': MockAuth,
-                '$translate': MockTranslate,
                 '$state': MockState
             };
             $controller('RegisterController', locals);
@@ -28,7 +26,6 @@ describe('Controller Tests', function () {
         it('should register the new user and automatically authenticate him',
             function () {
                 // given
-                MockTranslate.use.and.returnValue('en');
                 MockAccountService.register.and.returnValue($q.resolve());
                 MockAuth.login.and.returnValue($q.resolve());
                 MockState.go.and.returnValue($q.resolve());
@@ -38,12 +35,6 @@ describe('Controller Tests', function () {
                 // when
                 $scope.$apply($scope.register); // $q promises require an $apply
                 // then
-                expect(MockAccountService.register).toHaveBeenCalledWith({
-                    password: 'password',
-                    email: 'email',
-                    langKey: 'en'
-                });
-                expect(MockTranslate.use).toHaveBeenCalled();
                 expect($scope.errorEmailExists).toBeNull();
                 expect($scope.error).toBeNull();
                 expect(MockAuth.login).toHaveBeenCalledWith({


### PR DESCRIPTION
![capture](https://cloud.githubusercontent.com/assets/2377014/19146863/bdaa91fa-8bb5-11e6-945f-21c14302c0a8.PNG)
angular search for this dependency and its  unfoud :( this why you can't create new account 
![capture](https://cloud.githubusercontent.com/assets/2377014/19146927/01d1f490-8bb6-11e6-8c4e-14e816f6b76f.PNG)
